### PR TITLE
fix: update shebang to allow for Node.js installed via NVM

### DIFF
--- a/bin/open.js
+++ b/bin/open.js
@@ -1,4 +1,4 @@
-#!/usr/local/bin/node
+#!/usr/bin/env node
 
 const openBrowser = require("react-dev-utils/openBrowser");
 const chalk = require("chalk");


### PR DESCRIPTION
The existing shebang interpreter assumes that Node.js is installed as a system level package. Node installed via [NVM](https://github.com/nvm-sh/nvm) installs different versions of Node in a user's home directory.  This modification allows for both scenarios.